### PR TITLE
[Refactor] Changed endpoint to create verification flow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -11,8 +11,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php: [7.2, 7.3, 7.4]
+
     steps:
     - uses: actions/checkout@v2
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Install Dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - COMPOSER_FLAGS=""
 
 before_script:
+  - export XDEBUG_MODE=coverage
   - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 

--- a/src/MatiHttpClient.php
+++ b/src/MatiHttpClient.php
@@ -100,7 +100,7 @@ class MatiHttpClient implements MatiClientInterface
             $request->withHeaders(['User-Agent' => $user_agent]);
         }
 
-        return $request->post($this->getApiUrl() . '/identities', $payload)
+        return $request->post($this->getApiUrl() . '/verifications', $payload)
             ->throw();
     }
 


### PR DESCRIPTION
The /identites route is obsolete. Sample documentation: [create-verification](https://docs.getmati.com/#post-2-create-verification)